### PR TITLE
Add title metadata to all type definitions

### DIFF
--- a/specs/maas-v1.json
+++ b/specs/maas-v1.json
@@ -1,23 +1,4 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "version": "v1",
-    "title": "MaaS-TSP",
-    "description": "This is a API specification of REST endpoints that a Transport Service Provider (TSP) should implement to receive messages from MaaS. It is written in machine readable [Swagger](http://swagger.io/) format, so thatAPI endpoints, validators and test clients can be generated from the documentation.\n\nIn addition to this documentation, MaaS maintains a [reference implementation (**TODO**)](https://github.com/maasglobal/maas-tsp-api) with test cases. It is also running as a [reference service (**TODO**)](https://tsp.maas.global/).\n\nRight now MaaS TSP API consists of the Booking API. In addition, a need for customer feedback API (for mediating customer feedback to a TSP) and administration API (for changing API keys etc.) may be defined.\n",
-    "termsOfService": "http://api.maas.global/terms/",
-    "contact": {
-      "name": "MaaS API Team",
-      "email": "developers@maas.fi",
-      "url": "http://maas.fi/"
-    },
-    "license": {
-      "name": "MIT",
-      "url": "http://opensource.org/licenses/MIT"
-    }
-  },
-  "schemes": [
-    "https"
-  ],
   "tags": [
     {
       "name": "Booking",
@@ -36,92 +17,121 @@
       "description": "In the future MaaS will implement machine-readable APIs that a TSP may use to update GTFS route information, API keys and other information that is needed for communicating between MaaS and a TSP."
     }
   ],
-  "securityDefinitions": {
-    "key": {
-      "description": "MaaS can authenticate using an access token as part of the HTTP(S) headers. The keys are sent as part of every request that MaaS makes to the TSP API with a `x-api-key` custom header option.\n",
-      "type": "apiKey",
-      "name": "X-Api-Key",
-      "in": "header"
-    }
-  },
-  "security": [
-    {
-      "key": []
-    }
-  ],
   "paths": {
     "/bookings/": {
       "get": {
         "description": "Returns the `Booking` that has been created earlier",
-        "tags": [
-          "Booking"
-        ],
-        "schemes": [
-          "https"
-        ],
         "consumes": [
           "application/json"
         ],
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "state",
-            "description": "The state the booking to fetch",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "format": "enum - BOOKED - CANCELLED - PAID - UPDATE_REQUESTED - UPDATED - STARTED - FINISHED"
-          }
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "Booking"
         ],
         "responses": {
           "200": {
             "description": "The bookings matching the query",
             "schema": {
+              "x-oad-type": "array",
               "type": "array",
               "description": "The bookings that matched the query (zero or more)",
-              "minItems": 0,
               "items": {
+                "x-oad-type": "reference",
                 "$ref": "#/definitions/booking"
               }
-            }
+            },
+            "x-oad-type": "response"
           },
           "400": {
             "description": "Bad request (invalid query parameters)",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/error"
-            }
+            },
+            "x-oad-type": "response"
           },
           "401": {
             "description": "Authorization error (invalid API key)",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/error"
-            }
+            },
+            "x-oad-type": "response"
           },
           "default": {
             "description": "unexpected error",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/error"
-            }
+            },
+            "x-oad-type": "response"
           }
         },
-        "x-serverless-endpoint": "echo~GET"
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "description": "The state the booking to fetch",
+            "required": true,
+            "type": "string",
+            "format": "enum - BOOKED - CANCELLED - PAID - UPDATE_REQUESTED - UPDATED - STARTED - FINISHED",
+            "x-oad-type": "parameter"
+          }
+        ]
       },
       "post": {
         "description": "Creates a new `Booking` for the TSP in **booked** state. The returned object will be a refrence that is passed back & forth throughout the booking life cycle.\nThe Booking may be modified in the response, e.g. location being adjusted for a more suitable pick-up location.\nIn addition, the service may contain a **meta** attribute for arbitrary TSP metadata that the TSP needs later, and **token** attribute depicting how long the current state is valid.",
-        "tags": [
-          "Booking"
-        ],
-        "schemes": [
-          "https"
-        ],
         "consumes": [
           "application/json"
         ],
         "produces": [
           "application/json"
         ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "Booking"
+        ],
+        "responses": {
+          "200": {
+            "description": "A new booking was succesfully created",
+            "schema": {
+              "x-oad-type": "reference",
+              "$ref": "#/definitions/booking"
+            },
+            "x-oad-type": "response"
+          },
+          "400": {
+            "description": "Bad request (invalid body parameters)",
+            "schema": {
+              "x-oad-type": "reference",
+              "$ref": "#/definitions/error"
+            },
+            "x-oad-type": "response"
+          },
+          "401": {
+            "description": "Authorization error (invalid API key)",
+            "schema": {
+              "x-oad-type": "reference",
+              "$ref": "#/definitions/error"
+            },
+            "x-oad-type": "response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "x-oad-type": "reference",
+              "$ref": "#/definitions/error"
+            },
+            "x-oad-type": "response"
+          }
+        },
         "parameters": [
           {
             "name": "newBooking",
@@ -129,116 +139,123 @@
             "description": "New `Booking` data",
             "required": true,
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/newBooking"
-            }
+            },
+            "x-oad-type": "parameter"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "A new booking was succesfully created",
-            "schema": {
-              "$ref": "#/definitions/booking"
-            }
-          },
-          "400": {
-            "description": "Bad request (invalid body parameters)",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "401": {
-            "description": "Authorization error (invalid API key)",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
+        ]
+      },
+      "x-oad-type": "operation"
     },
     "/bookings/{id}": {
       "get": {
         "description": "Returns the `Bookings` that have been created through the system.",
-        "tags": [
-          "Booking"
-        ],
-        "schemes": [
-          "https"
-        ],
         "consumes": [
           "application/json"
         ],
         "produces": [
           "application/json"
         ],
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Booking identifier",
-            "required": true,
-            "type": "string"
-          }
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "Booking"
         ],
         "responses": {
           "200": {
             "description": "The booking was found",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/booking"
-            }
+            },
+            "x-oad-type": "response"
           },
           "400": {
             "description": "Bad request (invalid query or body parameters)",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/error"
-            }
+            },
+            "x-oad-type": "response"
           },
           "401": {
             "description": "Authorization error (invalid API key)",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/error"
-            }
+            },
+            "x-oad-type": "response"
           },
           "404": {
             "description": "The booking was not found",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/error"
-            }
+            },
+            "x-oad-type": "response"
           },
           "default": {
             "description": "Unexpected error",
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/error"
-            }
+            },
+            "x-oad-type": "response"
           }
-        }
-      },
-      "put": {
-        "description": "Modifies the state of a `Booking`, e.g. **cancels**, **pays** or **reschedules** it. The previous booking information is passed forward as-is for reference.",
-        "tags": [
-          "Booking"
-        ],
-        "schemes": [
-          "https"
-        ],
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
+        },
         "parameters": [
           {
             "name": "id",
             "in": "path",
             "description": "Booking identifier",
             "required": true,
-            "type": "string"
+            "type": "string",
+            "x-oad-type": "parameter"
+          }
+        ]
+      },
+      "put": {
+        "description": "Modifies the state of a `Booking`, e.g. **cancels**, **pays** or **reschedules** it. The previous booking information is passed forward as-is for reference.",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "https"
+        ],
+        "tags": [
+          "Booking"
+        ],
+        "responses": {
+          "200": {
+            "description": "The booking was modified",
+            "schema": {
+              "x-oad-type": "reference",
+              "$ref": "#/definitions/booking"
+            },
+            "x-oad-type": "response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "x-oad-type": "reference",
+              "$ref": "#/definitions/error"
+            },
+            "x-oad-type": "response"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Booking identifier",
+            "required": true,
+            "type": "string",
+            "x-oad-type": "parameter"
           },
           {
             "name": "booking",
@@ -246,107 +263,114 @@
             "description": "New `Booking` data",
             "required": true,
             "schema": {
+              "x-oad-type": "reference",
               "$ref": "#/definitions/booking"
-            }
+            },
+            "x-oad-type": "parameter"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "The booking was modified",
-            "schema": {
-              "$ref": "#/definitions/booking"
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "#/definitions/error"
-            }
-          }
-        }
-      }
+        ]
+      },
+      "x-oad-type": "operation"
     }
   },
   "definitions": {
     "error": {
+      "x-oad-type": "object",
       "type": "object",
+      "title": "Error",
       "description": "An error that the service may send, e.g. in case of invalid input, missing authorization or internal service error.",
-      "required": [
-        "message",
-        "code"
-      ],
       "properties": {
         "message": {
+          "x-oad-type": "string",
           "type": "string",
+          "title": "Message",
           "description": "A human readable error message (preferrably in English)"
         },
         "code": {
+          "x-oad-type": "string",
           "type": "string",
+          "title": "Code",
           "description": "A TSP internal error code, used for reference"
         }
-      }
+      },
+      "required": [
+        "message",
+        "code"
+      ]
     },
     "newBooking": {
+      "x-oad-type": "object",
       "type": "object",
+      "title": "New booking",
       "description": "A new booking, created by MaaS POST request in 'new' state",
-      "required": [
-        "leg",
-        "customer"
-      ],
       "properties": {
         "state": {
+          "x-oad-type": "string",
           "type": "string",
+          "title": "Booking state",
           "description": "The state of the booking (always new for new bookings)",
           "enum": [
             "NEW"
           ]
         },
         "leg": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/leg"
         },
         "customer": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/customer"
         }
-      }
+      },
+      "required": [
+        "leg",
+        "customer"
+      ]
     },
     "booking": {
+      "x-oad-type": "object",
       "type": "object",
+      "title": "Booking",
       "description": "The booking information describing the state and details of the transaction",
-      "allOf": [
-        {
-          "$ref": "#/definitions/newBooking"
-        }
-      ],
       "properties": {
         "id": {
-          "description": "The identifier MaaS will be using to referring to the booking",
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "ID",
+          "description": "The identifier MaaS will be using to referring to the booking"
         },
         "state": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/bookingState"
         },
         "terms": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/bookingState"
         },
         "token": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/token"
         },
         "meta": {
-          "description": "Arbitrary metadata that a TSP can add",
-          "type": "object"
+          "x-oad-type": "object",
+          "type": "object",
+          "title": "Meta",
+          "description": "Arbitrary metadata that a TSP can add"
         }
       },
       "required": [
         "id",
         "state",
-        "leg",
-        "customer",
+        null,
+        null,
         "token"
       ]
     },
     "bookingState": {
-      "description": "The life-cycle state of the booking (from NEW to FINISHED)",
+      "x-oad-type": "string",
       "type": "string",
+      "title": "Booking state",
+      "description": "The life-cycle state of the booking (from NEW to FINISHED)",
       "enum": [
         "NEW",
         "BOOKED",
@@ -358,102 +382,107 @@
         "FINISHED"
       ]
     },
-    "token": {
-      "description": "The validity token (such as booking ID, travel ticket etc.) that MaaS clients will display to validate the trip when starting the leg.",
-      "properties": {
-        "validityDuration": {
-          "description": "The rules that MaaS will interpret to schedule, re-validate or cancel the booking.",
-          "type": "object",
-          "properties": {
-            "from": {
-              "description": "The starting time from which the ticket is valid",
-              "$ref": "#/definitions/time"
-            },
-            "to": {
-              "description": "The finishing time the ticket is valid for",
-              "$ref": "#/definitions/time"
-            }
-          }
-        },
-        "meta": {
-          "description": "Arbitrary metadata the TSP may pass along the ticket to the client (e.g. a booking code, base64 encoded binary)",
-          "type": "object"
-        }
-      }
-    },
+    "token": {},
     "customer": {
+      "x-oad-type": "object",
       "type": "object",
+      "title": "Customer",
+      "properties": {
+        "id": {
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "ID",
+          "description": "The identifier MaaS uses to identify the customer"
+        },
+        "firstName": {
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "First name",
+          "description": "First name of the customer (e.g. John)"
+        },
+        "lastName": {
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Last name",
+          "description": "Last name of the customer (e.g. Doe)"
+        },
+        "phone": {
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Phone",
+          "description": "Phone number that the customer may be reached from"
+        }
+      },
       "required": [
         "id",
         "firstName",
         "lastName"
-      ],
-      "properties": {
-        "id": {
-          "description": "The identifier MaaS uses to identify the customer",
-          "type": "string"
-        },
-        "firstName": {
-          "description": "First name of the customer (e.g. John)",
-          "type": "string"
-        },
-        "lastName": {
-          "description": "Last name of the customer (e.g. Doe)",
-          "type": "string"
-        },
-        "phone": {
-          "description": "Phone number that the customer may be reached from",
-          "type": "string"
-        }
-      }
+      ]
     },
     "leg": {
+      "x-oad-type": "object",
       "type": "object",
+      "title": "Leg",
       "description": "A OpenTripPlanner compatible definition of a leg (see OpenTripPlanner docs for reference)",
-      "additionalProperties": true,
       "properties": {
         "from": {
-          "description": "The coordinates the TSP should use to resolve leg start location",
+          "x-oad-type": "reference",
           "$ref": "#/definitions/place"
         },
         "to": {
-          "description": "The coordinates the TSP should use to resolve leg finish location",
+          "x-oad-type": "reference",
           "$ref": "#/definitions/place"
         },
         "startTime": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/time"
         },
         "endTime": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/time"
         },
         "mode": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/mode"
         },
         "departureDelay": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/duration"
         },
         "arrivalDelay": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/duration"
         },
         "distance": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/distance"
         },
         "fare": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/fare"
         },
         "route": {
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Route"
         },
         "routeShortName": {
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Route short name"
         },
         "routeLongName": {
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Route long name"
         },
         "agencyId": {
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Agency ID"
         },
         "legGeometry": {
+          "x-oad-type": "reference",
           "$ref": "#/definitions/legGeometry"
         }
       },
@@ -466,28 +495,37 @@
       ]
     },
     "place": {
+      "x-oad-type": "object",
       "type": "object",
-      "additionalProperties": true,
+      "title": "Place",
       "properties": {
         "name": {
-          "description": "Human readable name of the place",
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Name",
+          "description": "Human readable name of the place"
         },
         "stopId": {
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Stop ID"
         },
         "stopCode": {
-          "type": "string"
+          "x-oad-type": "string",
+          "type": "string",
+          "title": "Stop code"
         },
         "lat": {
+          "x-oad-type": "number",
           "type": "number",
-          "minimum": -90,
-          "maximum": 90
+          "title": "Latitude",
+          "format": "float"
         },
         "lon": {
+          "x-oad-type": "number",
           "type": "number",
-          "minimum": -180,
-          "maximum": 180
+          "title": "Longitude",
+          "format": "float"
         }
       },
       "required": [
@@ -496,39 +534,49 @@
       ]
     },
     "legGeometry": {
+      "x-oad-type": "object",
       "type": "object",
-      "additionalProperties": true,
+      "title": "Leg geometry",
       "properties": {
         "points": {
+          "x-oad-type": "string",
           "type": "string",
-          "minLength": 1
+          "title": "Points"
         }
       }
     },
     "time": {
-      "description": "An UTC timestamp (number of milliseconds in a Date object since January 1, 1970, 00:00:00)",
+      "x-oad-type": "integer",
       "type": "integer",
-      "maximum": 2147483647,
-      "minimum": 0
+      "title": "Time",
+      "description": "An UTC timestamp (number of milliseconds in a Date object since January 1, 1970, 00:00:00)",
+      "format": "int32"
     },
     "duration": {
-      "description": "A duration of some time (relative to time) in milliseconds",
+      "x-oad-type": "integer",
       "type": "integer",
-      "maximum": 2147483647,
-      "minimum": 0
+      "title": "Duration",
+      "description": "A duration of some time (relative to time) in milliseconds",
+      "format": "int32"
     },
     "distance": {
-      "description": "The estimated distance travelled in the leg (in meters)",
+      "x-oad-type": "integer",
       "type": "integer",
-      "minimum": 0
+      "title": "Distance",
+      "description": "The estimated distance travelled in the leg (in meters)",
+      "format": "int32"
     },
     "fare": {
-      "description": "Arbitrary fare data that MaaS will use internally",
-      "type": "object"
+      "x-oad-type": "object",
+      "type": "object",
+      "title": "Fare",
+      "description": "Arbitrary fare data that MaaS will use internally"
     },
     "mode": {
-      "description": "The type of the leg MaaS uses to identify the leg",
+      "x-oad-type": "string",
       "type": "string",
+      "title": "Mode",
+      "description": "The type of the leg MaaS uses to identify the leg",
       "enum": [
         "WALK",
         "BICYCLE",
@@ -548,5 +596,38 @@
         "TAXI"
       ]
     }
-  }
+  },
+  "security": [
+    {
+      "key": []
+    }
+  ],
+  "securityDefinitions": {
+    "key": {
+      "description": "MaaS can authenticate using an access token as part of the HTTP(S) headers. The keys are sent as part of every request that MaaS makes to the TSP API with a `x-api-key` custom header option.\n",
+      "name": "X-Api-Key",
+      "in": "header",
+      "type": "apiKey"
+    }
+  },
+  "info": {
+    "title": "MaaS-TSP",
+    "version": "v1",
+    "description": "This is a API specification of REST endpoints that a Transport Service Provider (TSP) should implement to receive messages from MaaS. It is written in machine readable [Swagger](http://swagger.io/) format, so thatAPI endpoints, validators and test clients can be generated from the documentation.\n\nIn addition to this documentation, MaaS maintains a [reference implementation (**TODO**)](https://github.com/maasglobal/maas-tsp-api) with test cases. It is also running as a [reference service (**TODO**)](https://tsp.maas.global/).\n\nRight now MaaS TSP API consists of the Booking API. In addition, a need for customer feedback API (for mediating customer feedback to a TSP) and administration API (for changing API keys etc.) may be defined.\n",
+    "termsOfService": "http://api.maas.global/terms/",
+    "contact": {
+      "name": "MaaS API Team",
+      "email": "developers@maas.fi",
+      "url": "http://maas.fi/"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://opensource.org/licenses/MIT"
+    }
+  },
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "swagger": "2.0"
 }


### PR DESCRIPTION
Closes #9 

# Changes
- Added missing titles to all type definitions

# Note
The main reason for the 208 deletions is that the Swagger graphical editor ([OpenAPI Designer](https://openapi.design/)) reordered some of the secitons.