### PR TITLE
Gh pages deploy script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,8 +46,8 @@ gulp.task(
   shell.task(
     [
       'git checkout -b gh-pages-tmp',
-      // Move .gitignore, so it won't be active
-      'mv .gitignore .gitignore.backup',
+      // Remove .gitignore, so it won't be active
+      'rm .gitignore',
       // Add all files, including the newly built site files
       'git add .',
       'git commit -am "Remove gitignore; add built docs"',
@@ -70,11 +70,11 @@ gulp.task(
   shell.task(
     [
       // Switch back to master branch
-      'git checkout gh-pages-deploy-script',
+      'git checkout master',
       // Cleanup temp GitHub Pages branch
       'git branch --delete gh-pages-tmp',
       // Put .gitignore back in place
-      'mv .gitignore.backup .gitignore'
+      'git reset --hard HEAD'
     ]
   )
 )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ gulp.task('serve', function() {
 });
 
 gulp.task(
-  'create-temp-gh-pages-deployment-branch',
+  'deploy',
   shell.task(
     [
       'git checkout -b gh-pages-tmp',
@@ -50,27 +50,12 @@ gulp.task(
       'rm .gitignore',
       // Add all files, including the newly built site files
       'git add .',
+      // Commit all changes for deployment
       'git commit -am "Remove gitignore; add built docs"',
-    ]
-  )
-)
-
-gulp.task(
-  'deploy-temp-gh-pages-deployment-branch',
-  shell.task(
-    [
-      // Delete existing gh-pages branch
+      // Delete upstream gh-pages branch
       'git push upstream --delete gh-pages',
-      // Push the docs folder to the Github Pages branch
+      // Push the docs folder to the upstream Github Pages branch
       'git subtree push --prefix docs upstream gh-pages',
-    ]
-  )
-)
-
-gulp.task(
-  'delete-temp-gh-pages-deployment-branch',
-  shell.task(
-    [
       // Switch back to master branch
       'git checkout master',
       // Cleanup temp GitHub Pages branch
@@ -87,8 +72,3 @@ gulp.task('docs', ['copy-swagger-ui', 'copy-specs']);
 gulp.task('build', ['transform-yaml']);
 gulp.task('clean', ['clean:docs']);
 gulp.task('watch', ['watch-specs']);
-gulp.task('deploy', [
-  'create-temp-gh-pages-deployment-branch',
-  'deploy-temp-gh-pages-deployment-branch',
-  'delete-temp-gh-pages-deployment-branch',
-])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ const replace = require('gulp-replace');
 const yaml = require('gulp-yaml');
 const del = require('del');
 const connect = require('gulp-connect');
+const shell = require('gulp-shell')
 
 const swaggerRoot = 'specs/maas-v1.json'
 
@@ -40,9 +41,49 @@ gulp.task('serve', function() {
   });
 });
 
+gulp.task(
+  'create-temp-gh-pages-deployment-branch',
+  shell.task(
+    [
+      'git checkout -b gh-pages-tmp',
+      'rm .gitignore'
+    ]
+  )
+)
+
+gulp.task(
+  'deploy-temp-gh-pages-deployment-branch',
+  shell.task(
+    [
+      'git checkout -b gh-pages-tmp',
+      'rm .gitignore',
+      'git add .',
+      'git commit -am "Remove gitignore; add built docs"',
+      // Push the docs folder to the Github Pages branch
+      'git subtree push --prefix docs upstream gh-pages',
+    ]
+  )
+)
+
+gulp.task(
+  'delete-temp-gh-pages-deployment-branch',
+  shell.task(
+    [
+      // TODO: change the following line to 'git checkout master' after test
+      'git checkout gh-pages-deploy-script',
+      'git -d gh-pages-tmp'
+    ]
+  )
+)
+
 // Aliases
 
 gulp.task('docs', ['copy-swagger-ui', 'copy-specs']);
 gulp.task('build', ['transform-yaml']);
 gulp.task('clean', ['clean:docs']);
 gulp.task('watch', ['watch-specs']);
+gulp.task('deploy' [
+  'create-temp-gh-pages-deployment-branch',
+  'deploy-temp-gh-pages-deployment-branch',
+  'delete-temp-gh-pages-deployment-branch',
+])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ gulp.task(
   shell.task(
     [
       'git checkout -b gh-pages-tmp',
-      'rm .gitignore'
+      'mv .gitignore .gitignore.backup'
     ]
   )
 )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task(
       // Remove .gitignore, so it won't be active
       'rm .gitignore',
       // ignore node modules for temp gh pages branch commit
-      'echo "node_modules/" >> .gitignore'
+      'echo "node_modules/" >> .gitignore',
       // Add all files, including the newly built site files
       'git add .',
       // Commit all changes for deployment

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,7 @@ gulp.task(
     [
       // TODO: change the following line to 'git checkout master' after test
       'git checkout gh-pages-deploy-script',
-      'git -D gh-pages-tmp',
+      'git branch --delete gh-pages-tmp',
       'mv .gitignore.backup .gitignore'
     ]
   )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task(
   shell.task(
     [
       'git checkout -b gh-pages-tmp',
-      'rm .gitignore',
+      'mv .gitignore .gitignore.backup',
       'git add .',
       'git commit -am "Remove gitignore; add built docs"',
       // Push the docs folder to the Github Pages branch
@@ -71,7 +71,8 @@ gulp.task(
     [
       // TODO: change the following line to 'git checkout master' after test
       'git checkout gh-pages-deploy-script',
-      'git -d gh-pages-tmp'
+      'git -D gh-pages-tmp',
+      'mv .gitignore.backup .gitignore'
     ]
   )
 )
@@ -82,7 +83,7 @@ gulp.task('docs', ['copy-swagger-ui', 'copy-specs']);
 gulp.task('build', ['transform-yaml']);
 gulp.task('clean', ['clean:docs']);
 gulp.task('watch', ['watch-specs']);
-gulp.task('deploy' [
+gulp.task('deploy', [
   'create-temp-gh-pages-deployment-branch',
   'deploy-temp-gh-pages-deployment-branch',
   'delete-temp-gh-pages-deployment-branch',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,6 +59,8 @@ gulp.task(
   'deploy-temp-gh-pages-deployment-branch',
   shell.task(
     [
+      // Delete existing gh-pages branch
+      'git push upstream --delete gh-pages',
       // Push the docs folder to the Github Pages branch
       'git subtree push --prefix docs upstream gh-pages',
     ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,6 +48,8 @@ gulp.task(
       'git checkout -b gh-pages-tmp',
       // Remove .gitignore, so it won't be active
       'rm .gitignore',
+      // ignore node modules for temp gh pages branch commit
+      'echo "node_modules/" >> .gitignore'
       // Add all files, including the newly built site files
       'git add .',
       // Commit all changes for deployment

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,7 @@ gulp.task(
       // Switch back to master branch
       'git checkout master',
       // Cleanup temp GitHub Pages branch
-      'git branch --delete gh-pages-tmp',
+      'git branch -D gh-pages-tmp',
       // Put .gitignore back in place
       'git reset --hard HEAD'
     ]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,9 @@ gulp.task(
   shell.task(
     [
       'git checkout -b gh-pages-tmp',
+      // Move .gitignore, so it won't be active
       'mv .gitignore .gitignore.backup',
+      // Add all files, including the newly built site files
       'git add .',
       'git commit -am "Remove gitignore; add built docs"',
     ]
@@ -67,9 +69,11 @@ gulp.task(
   'delete-temp-gh-pages-deployment-branch',
   shell.task(
     [
-      // TODO: change the following line to 'git checkout master' after test
+      // Switch back to master branch
       'git checkout gh-pages-deploy-script',
+      // Cleanup temp GitHub Pages branch
       'git branch --delete gh-pages-tmp',
+      // Put .gitignore back in place
       'mv .gitignore.backup .gitignore'
     ]
   )

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,9 @@ gulp.task(
   shell.task(
     [
       'git checkout -b gh-pages-tmp',
-      'mv .gitignore .gitignore.backup'
+      'mv .gitignore .gitignore.backup',
+      'git add .',
+      'git commit -am "Remove gitignore; add built docs"',
     ]
   )
 )
@@ -55,10 +57,6 @@ gulp.task(
   'deploy-temp-gh-pages-deployment-branch',
   shell.task(
     [
-      'git checkout -b gh-pages-tmp',
-      'mv .gitignore .gitignore.backup',
-      'git add .',
-      'git commit -am "Remove gitignore; add built docs"',
       // Push the docs folder to the Github Pages branch
       'git subtree push --prefix docs upstream gh-pages',
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,28 @@
         "negotiator": "0.5.3"
       }
     },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-gray": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
       "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
       "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
@@ -118,6 +136,23 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
     },
     "atob": {
       "version": "2.0.3",
@@ -385,6 +420,21 @@
         "map-visit": "1.0.0",
         "object-visit": "1.0.1"
       }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-support": {
       "version": "1.1.3",
@@ -1354,6 +1404,77 @@
         }
       }
     },
+    "gulp-shell": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.6.5.tgz",
+      "integrity": "sha512-f3m1WcS0o2B72/PGj1Jbv9zYR9rynBh/EQJv64n01xQUo7j7anols0eww9GG/WtDTzGVQLrupVDYkifRFnj5Zg==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "chalk": "2.3.0",
+        "fancy-log": "1.3.2",
+        "lodash": "4.17.4",
+        "lodash.template": "4.4.0",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "lodash.template": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+          "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0",
+            "lodash.templatesettings": "4.1.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+          "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+          "dev": true,
+          "requires": {
+            "lodash._reinterpolate": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
@@ -1418,6 +1539,12 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "has-gulplog": {
       "version": "0.1.0",
@@ -2440,6 +2567,58 @@
       "dev": true,
       "requires": {
         "pinkie": "2.0.4"
+      }
+    },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "dev": true,
+      "requires": {
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "arr-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+          "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+          "dev": true
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
       }
     },
     "posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "node_modules/mocha/bin/mocha --require source-map-support/register test",
     "build": "node_modules/gulp/bin/gulp.js build docs",
     "start": "node_modules/gulp/bin/gulp.js serve",
-    "watch": "node_modules/gulp/bin/gulp.js watch serve"
+    "watch": "node_modules/gulp/bin/gulp.js watch serve",
+    "deploy": "node_modules/gulp/bin/gulp.js deploy"
   },
   "keywords": [
     "maas"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gulp": "^3.9.1",
     "gulp-connect": "^4.0.0",
     "gulp-replace": "^0.5.4",
+    "gulp-shell": "^0.6.5",
     "gulp-yaml": "^1.0.1",
     "swagger-ui-dist": "^3.0.0"
   },


### PR DESCRIPTION
Add a Gulp task to deploy changes to Github Pages branch. This way, we don't need to keep Swagger UI under revision control. Rather, we just create a temporary branch when deploying to gh-pages branch.