### PR TITLE
Add 409 Conflict response for bookingCreate

### DIFF
--- a/specs/booking.yml
+++ b/specs/booking.yml
@@ -440,6 +440,30 @@ paths:
                 Taxi:
                   summary: Taxi
                   externalValue: ../examples/taxi/booking-create-response.json
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/core/error.json
+        '401':
+          description: Authorization error (invalid API key)
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/core/error.json
+        '409':
+          description: Booking exists for this User. If TSP does not support more than one booking per user, it can indicate it by sending this response when WhimApp creates a new booking.
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/core/error.json
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/core/error.json
   /bookings/{tspId}:
     get:
       operationId: bookingGet

--- a/specs/booking.yml
+++ b/specs/booking.yml
@@ -199,7 +199,7 @@ tags:
       ## Paying a Booking
 
       When booking created it is already paid according to the options received and selected by User. See [Booking options](#section/Booking+options) for more information.
-      
+
       If booking can not be created the paid amount will be refunded to the User.
 
       ## Navigating a Route
@@ -265,6 +265,15 @@ tags:
 
       The same principle applies when TSP is communicating with WhimApp.
 
+      The error response body are defined as JSON in [JSON Schema](https://maasglobal.github.io/maas-schemas/html/core/error.html#code) and can contain additional fields, e.g.
+
+      ```json
+      {
+        code: "BOOKING_ALREADY_EXISTS",
+        message: "Active booking already exists for this user.",
+        bookingId: "deadbeefdeadbeefdeadcafe0000"
+      }
+      ```
     x-traitTag: true
   - name: Booking
     description: |
@@ -453,7 +462,11 @@ paths:
               schema:
                 $ref: ../schemas/core/error.json
         '409':
-          description: Booking exists for this User. If TSP does not support more than one booking per user, it can indicate it by sending this response when WhimApp creates a new booking.
+          description: |
+            Another Booking exists for this User.
+
+            If TSP does not support more than one booking per user, it can indicate it by sending this response when 
+            WhimApp creates a new booking. Booking ID can be specified as an extra property in a response. See [Error Cases](#section/Error-Cases) for more information.
           content:
             application/json:
               schema:

--- a/test/errors.spec.js
+++ b/test/errors.spec.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const Error = require('maas-schemas-ts/lib/core/error').Default;
+const typePromise = require('io-ts-promise');
+
+describe('Check examples', () => {
+  describe('errors', () => {
+    it('409 booking already exists on create', () => {
+      return typePromise.decode(Error, {
+        code: 'BOOKING_ALREADY_EXISTS',
+        message: 'Active booking already exists for this user.',
+        bookingId: 'deadbeefdeadbeefdeadcafe0000',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Booking exists for this User. If TSP does not support more than one booking per user, it can indicate it by sending this response when WhimApp creates a new booking.