### PR TITLE
Added link to schemas doc and fixed webhook schema

### DIFF
--- a/examples/bike/booking-options-response.json
+++ b/examples/bike/booking-options-response.json
@@ -1,0 +1,102 @@
+{
+  "options": [
+    {
+      "cost": {
+        "currency": "EUR",
+        "amount": 0
+      },
+      "leg": {
+        "mode": "BICYCLE",
+        "startTime": 1577955471706,
+        "endTime": 1577955471706,
+        "from": {
+          "lat": 60.178205,
+          "lon": 24.951532,
+          "name": "Hakaniemi",
+          "stationId": "2919219"
+        },
+        "to": {
+          "lat": 60.178205,
+          "lon": 24.951532,
+          "name": "Hakaniemi",
+          "stationId": "2919219"
+        }
+      },
+      "meta": {
+        "MODE_BICYCLE": {
+          "bike": {
+            "id": "fe6fd61c-550a-4dd9-8e33-a4d5de4375cf",
+            "code": 1201,
+            "location": {
+              "lat": 60.178205,
+              "lon": 24.951532
+            }
+          },
+          "pickupStationId": "2919219"
+        }
+      },
+      "terms": {
+        "fareRates": [
+          {
+            "amount": 6,
+            "startAt": 0,
+            "currency": "GBP",
+            "timeInterval": 86400
+          }
+        ]
+      },
+      "tspProduct": {
+        "id": "bicyclesinc1"
+      }
+    },
+    {
+      "cost": {
+        "currency": "EUR",
+        "amount": 0
+      },
+      "leg": {
+        "mode": "BICYCLE",
+        "startTime": 1577955471706,
+        "endTime": 1577955471706,
+        "from": {
+          "lat": 60.178205,
+          "lon": 24.951532,
+          "name": "Hakaniemi",
+          "stationId": "2919219"
+        },
+        "to": {
+          "lat": 60.178205,
+          "lon": 24.951532,
+          "name": "Hakaniemi",
+          "stationId": "2919219"
+        }
+      },
+      "meta": {
+        "MODE_BICYCLE": {
+          "bike": {
+            "id": "888fc74e-c924-4ef1-a8e4-dc241c4e7722",
+            "code": 1202,
+            "location": {
+              "lat": 60.178205,
+              "lon": 24.951532
+            }
+          },
+          "pickupStationId": "2919219"
+        }
+      },
+      "terms": {
+        "fareRates": [
+          {
+            "amount": 6,
+            "startAt": 0,
+            "currency": "GBP",
+            "timeInterval": 86400
+          }
+        ]
+      },
+      "tspProduct": {
+        "id": "bicyclesinc1"
+      }
+    }
+  ]
+}

--- a/examples/car/booking-options-response.json
+++ b/examples/car/booking-options-response.json
@@ -48,6 +48,55 @@
           { "amount": 70, "currency": "EUR", "timeInterval": 86400, "type": "maxRate" }
         ]
       }
+    },
+    {
+      "tspProduct": { "id": "carsharingabc1" },
+      "meta": {
+        "MODE_SHARED_CAR": {
+          "id": "123457",
+          "startEndGeoRegionUrl": "https://raw.githubusercontent.com/maasglobal/maas-tsp-api/master/examples/car/rental-region.geojson.json",
+          "pickupInfo": "<p>Cars are parked in EuroPark\n",
+          "name": "Toyota Aigo",
+          "description": "Toyota Aigo",
+          "image": "https://raw.githubusercontent.com/maasglobal/maas-tsp-api/master/examples/car/car.png",
+          "car": {
+            "passengers": 4,
+            "doors": [3, 3],
+            "luggage": [4, 2],
+            "transmission": "automatic",
+            "fuel": "gasoline",
+            "classification": "MBAR",
+            "registrationPlate": "ABC-124",
+            "location": { "lat": 60.1693, "lon": 24.9364 }
+          }
+        }
+      },
+      "leg": {
+        "mode": "SHARED_CAR",
+        "startTime": 1576587222500,
+        "endTime": 1576587822500,
+        "from": {
+          "name": "EuroPark P-Simonkenttä",
+          "address": "streetName:Simonkatu|streetNumber:5|zipCode:00100|city:Helsinki",
+          "lat": 60.1693,
+          "lon": 24.9364
+        },
+        "to": {
+          "name": "EuroPark P-Simonkenttä",
+          "address": "streetName:Simonkatu|streetNumber:5|zipCode:00100|city:Helsinki",
+          "lat": 60.1693,
+          "lon": 24.9364
+        }
+      },
+      "cost": { "amount": 20, "currency": "EUR" },
+      "terms": {
+        "validity": { "startTime": 1576587222500, "endTime": 1608144822500 },
+        "fareRates": [
+          { "amount": 20, "currency": "EUR", "timeInterval": 7500 },
+          { "amount": 4, "currency": "EUR", "startAt": 7500, "timeInterval": 1800 },
+          { "amount": 70, "currency": "EUR", "timeInterval": 86400, "type": "maxRate" }
+        ]
+      }
     }
   ]
 }

--- a/examples/scooter/booking-options-response.json
+++ b/examples/scooter/booking-options-response.json
@@ -44,6 +44,51 @@
       "tspProduct": {
         "id": "scooterinc1"
       }
+    },
+    {
+      "cost": {
+        "currency": "EUR",
+        "amount": 1
+      },
+      "leg": {
+        "mode": "SCOOTER",
+        "startTime": 1581937820752,
+        "endTime": 1581937880752,
+        "from": {
+          "lat": 60.433793,
+          "lon": 22.222447
+        },
+        "to": {
+          "lat": 60.435388,
+          "lon": 22.226404
+        }
+      },
+      "meta": {
+        "MODE_SCOOTER": {
+          "scooter": {
+            "id": "f1da7e2a-956a-42e8-b659-9c2f32b01ce4",
+            "code": 201012,
+            "battery": 30,
+            "location": {
+              "lat": 60.433793,
+              "lon": 22.222447
+            }
+          }
+        }
+      },
+      "terms": {
+        "fareRates": [
+          {
+            "amount": 0.2,
+            "currency": "EUR",
+            "timeInterval": 60,
+            "startAt": 0
+          }
+        ]
+      },
+      "tspProduct": {
+        "id": "scooterinc1"
+      }
     }
   ]
 }

--- a/examples/taxi/webhook-booking-update-status.json
+++ b/examples/taxi/webhook-booking-update-status.json
@@ -1,0 +1,22 @@
+{
+  "tspId": "deadbeef-deadbeef-deadbeef-beefdead-121111-211211",
+  "meta": {
+    "MODE_TAXI": {
+      "driver": {
+        "phone": "+358400000001"
+      },
+      "taxiCenter": {
+        "name": "Taksi Test1",
+        "phone": "+35850000000"
+      },
+      "dispatchOrderId": "212111",
+      "vehicleId": "1",
+      "vehicleDescription": "Tesla Model S",
+      "vehicleLocation": {
+        "lat": 60.21751,
+        "lon": 24.93388
+      }
+    }
+  },
+  "state": "ACTIVATED"
+}

--- a/specs/booking.yml
+++ b/specs/booking.yml
@@ -63,6 +63,7 @@ info:
 
       * [OpenAPI Specification](specs/booking.json)
       * [Documentation](?booking.json)
+      * [JSON Schema documentation](https://maasglobal.github.io/maas-schemas)
       * [SwaggerUI](swagger-ui.html?urls.primaryName=booking.yml)
       * Source code [repository](https://github.com/maasglobal/maas-tsp-api/)
 
@@ -120,7 +121,7 @@ tags:
 
       Booking represents state about one leg of a journey, connected with TSP specific information and state.
 
-      Data model as specified by [JSON Schema](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/core/booking.json) allows representing information about any type of transport and state. To better understand how the booking works, let's take a look at the basic states and essential parts of the booking data.
+      Data model as specified by [JSON Schema](https://maasglobal.github.io/maas-schemas/core/booking.html) allows representing information about any type of transport and state. To better understand how the booking works, let's take a look at the basic states and essential parts of the booking data.
 
       ### State
 
@@ -160,7 +161,7 @@ tags:
 
       ### Structure
 
-      See examples for a [Create booking](#operation/bookingCreate) or schema for [Booking create](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-create) to understand all available data in a booking.
+      See examples for a [Create booking](#operation/bookingCreate) or schema for [Booking create](https://maasglobal.github.io/maas-schemas/#tspbooking-create) to understand all available data in a booking.
 
       Here are the most essential parts of the booking data.
 
@@ -191,9 +192,9 @@ tags:
 
       | Related API   | Related schemas | Examples | 
       | --------- | --------- | ------ |
-      | [Available options](#operation/bookingOptionsGet) | [tsp/booking-options-list](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-options-list) |  TAXI - [response](examples/taxi/booking-options-response.json), SCOOTER - [response](examples/scooter/booking-options-response.json), CAR SHARING - [response](examples/car/booking-options-response.json) |
-      | [Available stations](#operation/stationsGet) | [tsp/stations-list](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/stations-list) | DOCKED BIKE - [response](examples/bike/stations-list-response.json) |
-      | [Retrieve station](#operation/stationGet) | [tsp/stations-retrieve](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/stations-retrieve) | DOCKED BIKE - [response](examples/bike/stations-retrieve-response.json) |
+      | [Available options](#operation/bookingOptionsGet) | [tsp/booking-options-list](https://maasglobal.github.io/maas-schemas/#tspbooking-options-list) |  TAXI - [response](examples/taxi/booking-options-response.json), SCOOTER - [response](examples/scooter/booking-options-response.json), CAR SHARING - [response](examples/car/booking-options-response.json) |
+      | [Available stations](#operation/stationsGet) | [tsp/stations-list](https://maasglobal.github.io/maas-schemas/#tspstations-list) | DOCKED BIKE - [response](examples/bike/stations-list-response.json) |
+      | [Retrieve station](#operation/stationGet) | [tsp/stations-retrieve](https://maasglobal.github.io/maas-schemas/#tspstations-retrieve) | DOCKED BIKE - [response](examples/bike/stations-retrieve-response.json) |
 
       ## Creating a booking
 
@@ -216,10 +217,10 @@ tags:
 
       | Related API   | Related schemas | Examples | 
       | --------- | --------- | ------ |
-      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-create) | TAXI - [request](examples/taxi/booking-create-request.json), [response](examples/taxi/booking-create-response.json) |
-      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-create) | SCOOTER - [request](examples/scooter/booking-create-request.json), [response](examples/scooter/booking-create-response.json) |
-      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-create) | CAR SHARING - [request](examples/car/booking-create-request.json), [response](examples/car/booking-create-response.json) |
-      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-create) | **v.1.2.0-future**: DOCKED BIKE -  [response](examples/bike/booking-create-response.json) |
+      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://maasglobal.github.io/maas-schemas/#tspbooking-create) | TAXI - [request](examples/taxi/booking-create-request.json), [response](examples/taxi/booking-create-response.json) |
+      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://maasglobal.github.io/maas-schemas/#tspbooking-create) | SCOOTER - [request](examples/scooter/booking-create-request.json), [response](examples/scooter/booking-create-response.json) |
+      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://maasglobal.github.io/maas-schemas/#tspbooking-create) | CAR SHARING - [request](examples/car/booking-create-request.json), [response](examples/car/booking-create-response.json) |
+      | [Create booking](#operation/bookingCreate) | [tsp/booking-create](https://maasglobal.github.io/maas-schemas/#tspbooking-create) | **v.1.2.0-future**: DOCKED BIKE -  [response](examples/bike/booking-create-response.json) |
 
       ## Paying a booking
 
@@ -243,10 +244,10 @@ tags:
 
       | Related API   | Related schemas | Examples | 
       | --------- | --------- | ------ |
-      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-update) | SCOOTER, finish a ride - [request](examples/scooter/booking-update-expired-request.json), [response](examples/scooter/booking-update-expired-response.json) |
-      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-update) | CAR SHARING, lock - [request](examples/car/booking-update-request-lock.json), [response](examples/car/booking-update-response-lock.json)|
-      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-update) | CAR SHARING, unlock - [request](examples/car/booking-update-request-unlock.json) |
-      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-update) | **v.1.2.0-future**: DOCKED BIKE, reserve dock - [request](examples/bike/booking-update-request-reserve-dock.json), [response](examples/bike/booking-update-response-reserve-dock.json) |
+      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://maasglobal.github.io/maas-schemas/#tspbooking-update) | SCOOTER, finish a ride - [request](examples/scooter/booking-update-expired-request.json), [response](examples/scooter/booking-update-expired-response.json) |
+      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://maasglobal.github.io/maas-schemas/#tspbooking-update) | CAR SHARING, lock - [request](examples/car/booking-update-request-lock.json), [response](examples/car/booking-update-response-lock.json)|
+      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://maasglobal.github.io/maas-schemas/#tspbooking-update) | CAR SHARING, unlock - [request](examples/car/booking-update-request-unlock.json) |
+      | [Update booking](#operation/bookingUpdate) | [tsp/booking-update](https://maasglobal.github.io/maas-schemas/#tspbooking-update) | **v.1.2.0-future**: DOCKED BIKE, reserve dock - [request](examples/bike/booking-update-request-reserve-dock.json), [response](examples/bike/booking-update-response-reserve-dock.json) |
 
       ## Cancelling a booking
 
@@ -256,7 +257,7 @@ tags:
 
       | Related API   | Related schemas | Examples | 
       | --------- | --------- | ------ |
-      | [Cancel booking](#operation/bookingCancel) | [tsp/booking-cancel](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-cancel) | CAR SHARING - [response](examples/car/booking-cancel-response.json) |
+      | [Cancel booking](#operation/bookingCancel) | [tsp/booking-cancel](https://maasglobal.github.io/maas-schemas/#tspbooking-cancel  ) | CAR SHARING - [response](examples/car/booking-cancel-response.json) |
 
       ## Tracking a booking
 
@@ -269,10 +270,10 @@ tags:
 
       | Related API   | Related schemas | Examples | 
       | --------- | --------- | ------ |
-      | [Get booking](#operation/bookingGet) | [tsp/booking-read-by-id](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-read-by-id) | TAXI - [RESERVED](examples/taxi/booking-read-by-id-response.json), [ACTIVATED](examples/taxi/booking-read-by-id-response-activated.json) |
-      | [Get booking](#operation/bookingGet) | [tsp/booking-read-by-id](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-read-by-id) | SCOOTER - [ACTIVATED](examples/scooter/booking-read-by-id-response-activated.json) |
-      | [Update booking state](#operation/backendBookingReceive) | [tsp/booking-read-by-id](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-read-by-id) | See [above](#section/Updating-a-booking) |
-      | [Get receipt](#operation/bookingGetReceipt) | - | SCOOTER - [response](examples/scooter/booking-receipt-response.json) | 
+      | [Get booking](#operation/bookingGet) | [tsp/booking-read-by-id](https://maasglobal.github.io/maas-schemas/#tspbooking-read-by-id) | TAXI - [RESERVED](examples/taxi/booking-read-by-id-response.json), [ACTIVATED](examples/taxi/booking-read-by-id-response-activated.json) |
+      | [Get booking](#operation/bookingGet) | [tsp/booking-read-by-id](https://maasglobal.github.io/maas-schemas/#tspbooking-read-by-id) | SCOOTER - [ACTIVATED](examples/scooter/booking-read-by-id-response-activated.json) |
+      | [Update booking state](#operation/backendBookingReceive) | [tsp/booking-read-by-id](https://maasglobal.github.io/maas-schemas/#tspbooking-read-by-id) | See [above](#section/Updating-a-booking) |
+      | [Get receipt](#operation/bookingGetReceipt) | [tsp/booking-receipt](https://maasglobal.github.io/maas-schemas/#tspbooking-receipt) | SCOOTER - [response](examples/scooter/booking-receipt-response.json) | 
 
       ## Error Cases
 
@@ -280,7 +281,7 @@ tags:
 
       The same principle applies when TSP is communicating with WhimApp.
 
-      The error response body are defined as JSON in [JSON Schema](https://maasglobal.github.io/maas-schemas/html/core/error.html#code) and can contain additional fields, e.g.
+      The error response body are defined as JSON in [JSON Schema](https://maasglobal.github.io/maas-schemas/core/error.html#code) and can contain additional fields, e.g.
 
       ```json
       {
@@ -349,7 +350,7 @@ paths:
 
         The options are used to construct a booking to be created after the User selects it by calling [Create booking](#operation/bookingCreate).
 
-        Full schema for parameters defined in [maas-schemas](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-options-list/request.json) project
+        Full schema for parameters defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/booking-options-list/request.html) project
       tags:
         - Booking
       parameters:
@@ -440,6 +441,10 @@ paths:
           x-summary: Array of options
           description: |
             Available transport options matching the given query parameters. If no transport options are available; an empty array is returned.
+
+            ### JSON Schema documentation
+
+            Full schema for response defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/booking-options-list/response.html) project
           content:
             application/json:
               schema:
@@ -471,7 +476,7 @@ paths:
 
         ### JSON Schema documentation
 
-        Full schema for parameters defined in [maas-schemas](https://github.com/maasglobal/maas-schemas/blob/develop/maas-schemas/schemas/tsp/booking-create/request.json) project
+        Full schema for request defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/booking-create/request.html) project
       tags:
         - Booking
       requestBody:
@@ -498,6 +503,10 @@ paths:
           x-summary: Booking
           description: |
             Booking information. For more information about the booking, see [Booking explained](#section/Booking-explained).
+            
+            ### JSON Schema documentation
+
+            Full schema for response defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/booking-create/response.html) project
           content:
             application/json:
               schema:
@@ -544,7 +553,12 @@ paths:
     get:
       operationId: bookingGet
       summary: Get booking
-      description: Returns the booking that has been created earlier.
+      description: |
+        Returns the booking that has been created earlier.
+
+        ### JSON Schema documentation
+
+        Full schema for response defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/booking-read-by-id/response.html) project
       tags:
         - Booking
       parameters:
@@ -594,6 +608,10 @@ paths:
       summary: Update booking
       description: |
         Update booking, changing state, or changing booking details.
+
+        ### JSON Schema documentation
+
+        Full schema for request defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/booking-update/request.html) project
       tags:
         - Booking
       parameters:
@@ -708,6 +726,10 @@ paths:
       summary: Get final booking receipt
       description: |
         Get finalized pricing and receipt for the booking.
+
+        ### JSON Schema documentation
+
+        Full schema for response defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/booking-receipt/response.html) project
       tags:
         - Booking
       parameters:
@@ -756,7 +778,12 @@ paths:
     get:
       operationId: stationsGet
       summary: Get stations
-      description: Returns the list of stations
+      description: |
+        Returns the list of stations
+
+        ### JSON Schema documentation
+
+        Full schema for response defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/stations-list/response.html) project
       tags:
         - Stations
       parameters:
@@ -811,7 +838,12 @@ paths:
     get:
       operationId: stationGet
       summary: Get station
-      description: Returns the information about the specific station
+      description: |
+        Returns the information about the specific station
+
+        ### JSON Schema documentation
+
+        Full schema for response defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/stations-retrieve/response.html) project
       tags:
         - Stations
       parameters:
@@ -864,6 +896,10 @@ paths:
         Updates booking information at the WhimApp backend. 
 
         It is called by the TSP whenever the state of the booking are updated.
+
+        ### JSON Schema documentation
+
+        Full schema for payload defined in [maas-schemas](https://maasglobal.github.io/maas-schemas/tsp/webhooks-bookings-update/remote-request.html) project
       parameters:
         - name: tspId
           description: ID of the booking created earlier
@@ -877,11 +913,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: ../schemas/tsp/booking-read-by-id/response.json
+              $ref: ../schemas/tsp/webhooks-bookings-update/remote-request.json
             examples:
               Taxi:
                 summary: Taxi
-                externalValue: '../examples/taxi/booking-read-by-id-response-activated.json'
+                externalValue: '../examples/taxi/webhook-booking-update-status.json'
         description: |
           Booking information with updated state.
         required: true

--- a/specs/booking.yml
+++ b/specs/booking.yml
@@ -192,7 +192,10 @@ tags:
 
       | Related API   | Related schemas | Examples | 
       | --------- | --------- | ------ |
-      | [Available options](#operation/bookingOptionsGet) | [tsp/booking-options-list](https://maasglobal.github.io/maas-schemas/#tspbooking-options-list) |  TAXI - [response](examples/taxi/booking-options-response.json), SCOOTER - [response](examples/scooter/booking-options-response.json), CAR SHARING - [response](examples/car/booking-options-response.json) |
+      | [Available taxi types](#operation/bookingOptionsGet) | [tsp/booking-options-list](https://maasglobal.github.io/maas-schemas/#tspbooking-options-list) | TAXI - [response](examples/taxi/booking-options-response.json) |
+      | [Available scooters](#operation/bookingOptionsGet) | [tsp/booking-options-list](https://maasglobal.github.io/maas-schemas/#tspbooking-options-list) | SCOOTER - [response](examples/scooter/booking-options-response.json) |
+      | [Available cars](#operation/bookingOptionsGet) | [tsp/booking-options-list](https://maasglobal.github.io/maas-schemas/#tspbooking-options-list) | CAR SHARING - [response](examples/car/booking-options-response.json) |
+      | [Available bikes](#operation/bookingOptionsGet) | [tsp/booking-options-list](https://maasglobal.github.io/maas-schemas/#tspbooking-options-list) | DOCKED BIKE - [response](examples/bike/booking-options-response.json) |
       | [Available stations](#operation/stationsGet) | [tsp/stations-list](https://maasglobal.github.io/maas-schemas/#tspstations-list) | DOCKED BIKE - [response](examples/bike/stations-list-response.json) |
       | [Retrieve station](#operation/stationGet) | [tsp/stations-retrieve](https://maasglobal.github.io/maas-schemas/#tspstations-retrieve) | DOCKED BIKE - [response](examples/bike/stations-retrieve-response.json) |
 
@@ -891,7 +894,7 @@ paths:
   /backend/booking/{tspId}:
     patch:
       operationId: backendBookingReceive
-      summary: Update booking state
+      summary: Receive updated booking state
       description: |
         Updates booking information at the WhimApp backend. 
 

--- a/test/examples.spec.js
+++ b/test/examples.spec.js
@@ -8,6 +8,7 @@ const BookingCancelResponse = require('maas-schemas-ts/lib/tsp/booking-cancel/re
 const BookingOptionsResponse = require('maas-schemas-ts/lib/tsp/booking-options-list/response').Default;
 const BookingReadByIdResponse = require('maas-schemas-ts/lib/tsp/booking-read-by-id/response').Default;
 const BookingReceiptResponse = require('maas-schemas-ts/lib/tsp/booking-receipt/response').Default;
+const WebhookBookingUpdate = require('maas-schemas-ts/lib/tsp/webhooks-bookings-update/remote-request').Default;
 const StationsListResponse = require('maas-schemas-ts/lib/tsp/stations-list/response').Default;
 const StationsRetrieveResponse = require('maas-schemas-ts/lib/tsp/stations-retrieve/response').Default;
 const typePromise = require('io-ts-promise');
@@ -61,6 +62,13 @@ describe('Check examples', () => {
       return typePromise.decode(
         BookingReadByIdResponse,
         JSON.parse(fs.readFileSync('./examples/taxi/booking-read-by-id-response-activated.json'))
+      );
+    });
+
+    it('webhook-booking-update-status.json', () => {
+      return typePromise.decode(
+        WebhookBookingUpdate,
+        JSON.parse(fs.readFileSync('./examples/taxi/webhook-booking-update-status.json'))
       );
     });
   });

--- a/test/examples.spec.js
+++ b/test/examples.spec.js
@@ -125,6 +125,13 @@ describe('Check examples', () => {
   });
 
   describe('bike', () => {
+    it('booking-options-response.json', () => {
+      return typePromise.decode(
+        BookingOptionsResponse,
+        JSON.parse(fs.readFileSync('./examples/bike/booking-options-response.json'))
+      );
+    });
+
     it('booking-create-response.json', () => {
       return typePromise.decode(
         BookingCreateResponse,


### PR DESCRIPTION
Links not the raw github.com URLs but to published github pages docs: https://maasglobal.github.io/maas-schemas/

Also fixed type for webhook when booking update are called from TSP side
Based on #68 so it must be merged first

Published here: https://huksley.github.io/maas-tsp-api/