### PR TITLE
Fix response types, never use core/booking

### DIFF
--- a/specs/booking.yml
+++ b/specs/booking.yml
@@ -560,7 +560,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ../schemas/core/booking.json
+                $ref: ../schemas/tsp/booking-read-by-id/response.json
               examples:
                 Taxi1:
                   summary: Taxi - RESERVED
@@ -624,7 +624,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ../schemas/core/booking.json
+                $ref: ../schemas/tsp/booking-update/response.json
               examples:
                 CarSharing:
                   summary: Car sharing response lock
@@ -671,7 +671,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: ../schemas/core/booking.json
+                $ref: ../schemas/tsp/booking-cancel/response.json
               examples:
                 CarSharing:
                   summary: Car sharing cancel


### PR DESCRIPTION
https://maasglobal.github.io/maas-schemas/core/booking.html
is an backend respresentation of the booking

`booking.id` is a UUID of booking as it stored in backend
`booking.tspId` is a free form id TSP assign and use (can be any alphanumeric)